### PR TITLE
Bugfix for SpinFormatter

### DIFF
--- a/lib/src/spin_formatter.dart
+++ b/lib/src/spin_formatter.dart
@@ -38,7 +38,7 @@ class SpinFormatter extends TextInputFormatter {
       TextEditingValue oldValue, TextEditingValue newValue) {
     final input = newValue.text;
     if (input.isEmpty || (min < 0 && input == '-')) {
-      return newValue;
+      return oldValue;
     }
     final value = double.tryParse(input);
     if (value == null ||


### PR DESCRIPTION
Bug causes text input to allow empty input, or "-" when we should return the old value.