### PR TITLE
update text on focus change

### DIFF
--- a/lib/src/base_spin_box.dart
+++ b/lib/src/base_spin_box.dart
@@ -63,6 +63,7 @@ abstract class BaseSpinBoxState<T extends BaseSpinBox> extends State<T> {
     _controller.addListener(_updateValue);
     _focusNode = FocusNode(onKey: (node, event) => _handleKey(event));
     _focusNode.addListener(() => setState(_selectAll));
+    _focusNode.addListener(makeTextEditValidOnFocusChanged);
   }
 
   @override
@@ -110,10 +111,19 @@ abstract class BaseSpinBoxState<T extends BaseSpinBox> extends State<T> {
     return true;
   }
 
-  void makeTextEditValid(String newValue){
+  void makeTextEditValidOnSubmit(String newValue) {
     if (newValue.isEmpty || widget.min < 0 && newValue == '-') {
       _controller.text = _formatText(_cachedValue); // will trigger notify to _updateValue()
-    }else{
+    } else {
+      _cachedValue = _value;
+    }
+  }
+
+  void makeTextEditValidOnFocusChanged() {
+    if (hasFocus) return;
+    if (_controller.text == "" || widget.min < 0 && _controller.text == '-') {
+      _controller.text = _formatText(_cachedValue); // will trigger notify to _updateValue()
+    } else {
       _cachedValue = _value;
     }
   }

--- a/lib/src/cupertino/spin_box.dart
+++ b/lib/src/cupertino/spin_box.dart
@@ -274,7 +274,7 @@ class _CupertinoSpinBoxState extends BaseSpinBoxState<CupertinoSpinBox> {
       autofocus: widget.autofocus,
       enabled: widget.enabled,
       focusNode: focusNode,
-      onSubmitted: makeTextEditValid,
+      onSubmitted: makeTextEditValidOnSubmit,
     );
 
     if (isHorizontal) {

--- a/lib/src/material/spin_box.dart
+++ b/lib/src/material/spin_box.dart
@@ -328,7 +328,7 @@ class _SpinBoxState extends BaseSpinBoxState<SpinBox> {
       autofocus: widget.autofocus,
       enabled: widget.enabled,
       focusNode: focusNode,
-      onSubmitted: makeTextEditValid,
+      onSubmitted: makeTextEditValidOnSubmit,
     );
 
     if (isHorizontal) {


### PR DESCRIPTION
This fixes the same issue as the previous fix but for the case if the focus changed away from the textField, e.g. if we deleted the current text, then clicked away to a different widget without submitting the current (empty) text.

Both cases (onSubmitted, onFocusChanged) should probably gets tests added but I haven't had time to do them.