### PR TITLE
Fix input validation (#8)

### DIFF
--- a/lib/src/base_spin_box.dart
+++ b/lib/src/base_spin_box.dart
@@ -64,7 +64,6 @@ abstract class BaseSpinBoxState<T extends BaseSpinBox> extends State<T> {
     _controller.addListener(_updateValue);
     _focusNode = FocusNode(onKey: (node, event) => _handleKey(event));
     _focusNode.addListener(() => setState(_selectAll));
-    //_focusNode.addListener(makeTextEditValidOnFocusChanged);
     _focusNode.addListener(() {
       if (hasFocus) return;
       fixupValue(controller.text);
@@ -118,7 +117,8 @@ abstract class BaseSpinBoxState<T extends BaseSpinBox> extends State<T> {
 
   @protected
   void fixupValue(String value) {
-    if (value.isEmpty || (widget.min < 0 && value == '-')) {
+    final v = _parseValue(value);
+    if (value.isEmpty || (v < widget.min || v > widget.max)) {
       // will trigger notify to _updateValue()
       _controller.text = _formatText(_cachedValue);
     } else {

--- a/test/cupertino_spinbox_test.dart
+++ b/test/cupertino_spinbox_test.dart
@@ -23,8 +23,14 @@ void main() {
     return TestApp(CupertinoSpinBox(value: 1, autofocus: true));
   });
 
+  testRange<CupertinoSpinBox>(() {
+    return TestApp(
+        CupertinoSpinBox(min: 10, max: 30, value: 20, autofocus: true));
+  });
+
   testDecimals<CupertinoSpinBox>(() {
-    return TestApp(CupertinoSpinBox(min: -1, max: 1, value: 0.5, decimals: 2));
+    return TestApp(CupertinoSpinBox(
+        min: -1, max: 1, value: 0.5, decimals: 2, autofocus: true));
   });
 
   testCallbacks<CupertinoSpinBox>((onChanged) {

--- a/test/material_spinbox_test.dart
+++ b/test/material_spinbox_test.dart
@@ -23,8 +23,13 @@ void main() {
     return TestApp(SpinBox(value: 1, autofocus: true));
   });
 
+  testRange<SpinBox>(() {
+    return TestApp(SpinBox(min: 10, max: 30, value: 20, autofocus: true));
+  });
+
   testDecimals<SpinBox>(() {
-    return TestApp(SpinBox(min: -1, max: 1, value: 0.5, decimals: 2));
+    return TestApp(
+        SpinBox(min: -1, max: 1, value: 0.5, decimals: 2, autofocus: true));
   });
 
   testCallbacks<SpinBox>((onChanged) {

--- a/test/test_spinbox.dart
+++ b/test/test_spinbox.dart
@@ -174,19 +174,19 @@ void testInput<S>(TestBuilder builder) {
     });
 
     testUI('submit', (tester) async {
-      await tester.showKeyboard(find.editableText);
       tester.testTextInput.updateEditingValue(TextEditingValue.empty);
       await tester.idle();
       expect(tester.state(find.byType(S)), hasValue(0));
+      expect(find.editableText, hasText(''));
 
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.idle();
       expect(find.editableText, hasNoFocus);
       expect(tester.state(find.byType(S)), hasValue(1));
+      expect(find.editableText, hasText('1'));
     });
 
     testUI('unfocus', (tester) async {
-      await tester.showKeyboard(find.editableText);
       tester.testTextInput.updateEditingValue(TextEditingValue.empty);
       await tester.idle();
       expect(tester.state(find.byType(S)), hasValue(0));
@@ -195,6 +195,59 @@ void testInput<S>(TestBuilder builder) {
       await tester.idle();
       expect(find.editableText, hasNoFocus);
       expect(tester.state(find.byType(S)), hasValue(1));
+      expect(find.editableText, hasText('1'));
+    });
+  });
+}
+
+void testRange<S>(TestBuilder builder) {
+  group('range', () {
+    setUpUI((tester) async {
+      await tester.pumpWidget(builder());
+      expect(find.editableText, hasFocus);
+      await tester.showKeyboard(find.byType(S));
+    });
+
+    testUI('min', (tester) async {
+      await tester.pumpWidget(builder());
+      expect(find.editableText, hasFocus);
+      await tester.showKeyboard(find.byType(S));
+
+      expect(find.editableText, hasSelection(0, 2));
+      expect(find.editableText, hasText('20'));
+
+      tester.testTextInput.enterText('9');
+      await tester.idle();
+      expect(tester.state(find.byType(S)), hasValue(9));
+      expect(find.editableText, hasNoSelection);
+      expect(find.editableText, hasText('9'));
+
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.idle();
+      expect(find.editableText, hasNoFocus);
+      expect(tester.state(find.byType(S)), hasValue(20));
+      expect(find.editableText, hasText('20'));
+    });
+
+    testUI('max', (tester) async {
+      await tester.pumpWidget(builder());
+      expect(find.editableText, hasFocus);
+      await tester.showKeyboard(find.byType(S));
+
+      expect(find.editableText, hasSelection(0, 2));
+      expect(find.editableText, hasText('20'));
+
+      tester.testTextInput.enterText('31');
+      await tester.idle();
+      expect(tester.state(find.byType(S)), hasValue(20));
+      expect(find.editableText, hasSelection(0, 2));
+      expect(find.editableText, hasText('20'));
+
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.idle();
+      expect(find.editableText, hasNoFocus);
+      expect(tester.state(find.byType(S)), hasValue(20));
+      expect(find.editableText, hasText('20'));
     });
   });
 }
@@ -202,7 +255,15 @@ void testInput<S>(TestBuilder builder) {
 void testDecimals<S>(TestBuilder builder) {
   testUI('decimals', (tester) async {
     await tester.pumpWidget(builder());
+    expect(find.editableText, hasFocus);
+    await tester.showKeyboard(find.byType(S));
 
+    expect(tester.state(find.byType(S)), hasValue(0.5));
+    expect(find.editableText, hasSelection(0, 4));
+    expect(find.editableText, hasText('0.50'));
+
+    tester.testTextInput.enterText('0.50123');
+    await tester.idle();
     expect(tester.state(find.byType(S)), hasValue(0.5));
     expect(find.editableText, hasText('0.50'));
   });


### PR DESCRIPTION
Make it less strict and allow entering e.g. '9' when the minimum value
is 10. The value is fixed up when submitted or input focus is lost.