### PR TITLE
Show the ripple effect above the TextField

### DIFF
--- a/lib/src/material/spin_button.dart
+++ b/lib/src/material/spin_button.dart
@@ -48,17 +48,22 @@ class SpinButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SpinGesture(
-      enabled: enabled,
-      step: step,
-      interval: interval,
-      acceleration: acceleration,
-      onStep: onStep,
-      child: IconButton(
-        icon: icon,
-        color: color,
-        iconSize: icon.size ?? 24,
-        onPressed: enabled ? () => onStep(step) : null,
+    return Material(
+      shape: const CircleBorder(),
+      color: Colors.transparent,
+      clipBehavior: Clip.antiAlias,
+      child: SpinGesture(
+        enabled: enabled,
+        step: step,
+        interval: interval,
+        acceleration: acceleration,
+        onStep: onStep,
+        child: IconButton(
+          icon: icon,
+          color: color,
+          iconSize: icon.size ?? 24,
+          onPressed: enabled ? () => onStep(step) : null,
+        ),
       ),
     );
   }


### PR DESCRIPTION
#21

Adding the Material component causes the ripple effect to show above the TextField, this way when we use a InputDecoration on the TextFIeld, the effect doesn't show behind. 