### PR TITLE
Add onSubmitted

### DIFF
--- a/lib/src/base_spin_box.dart
+++ b/lib/src/base_spin_box.dart
@@ -38,6 +38,7 @@ abstract class BaseSpinBox extends StatefulWidget {
   int get decimals;
   int get digits;
   ValueChanged<double>? get onChanged;
+  void Function(double value)? get onSubmitted;
   bool Function(double value)? get canChange;
   VoidCallback? get beforeChange;
   VoidCallback? get afterChange;
@@ -154,6 +155,7 @@ mixin SpinBoxMixin<T extends BaseSpinBox> on State<T> {
     } else {
       _cachedValue = _value;
     }
+    widget.onSubmitted?.call(_cachedValue);
   }
 
   void _handleFocusChanged() {

--- a/lib/src/cupertino/spin_box.dart
+++ b/lib/src/cupertino/spin_box.dart
@@ -80,6 +80,7 @@ class CupertinoSpinBox extends BaseSpinBox {
     this.enableInteractiveSelection = true,
     this.spacing = 8,
     this.onChanged,
+    this.onSubmitted,
     this.canChange,
     this.beforeChange,
     this.afterChange,
@@ -254,6 +255,10 @@ class CupertinoSpinBox extends BaseSpinBox {
 
   /// See [CupertinoTextField.toolbarOptions].
   final ToolbarOptions? toolbarOptions;
+
+  /// See [CupertinoTextField.onSubmitted]. Is called with a formatted value.
+  @override
+  final void Function(double)? onSubmitted;
 
   @override
   State<CupertinoSpinBox> createState() => _CupertinoSpinBoxState();

--- a/lib/src/material/spin_box.dart
+++ b/lib/src/material/spin_box.dart
@@ -82,6 +82,7 @@ class SpinBox extends BaseSpinBox {
     this.enableInteractiveSelection = true,
     this.spacing = 8,
     this.onChanged,
+    this.onSubmitted,
     this.canChange,
     this.beforeChange,
     this.afterChange,
@@ -262,6 +263,10 @@ class SpinBox extends BaseSpinBox {
 
   /// See [TextField.toolbarOptions].
   final ToolbarOptions? toolbarOptions;
+
+  /// See [TextField.onSubmitted]. Is called with a formatted value.
+  @override
+  final void Function(double)? onSubmitted;
 
   @override
   State<SpinBox> createState() => _SpinBoxState();


### PR DESCRIPTION
There are some cases where we only want to perform an action after a user has "submitted" their input instead of on every change.

This PR allows us to specify a custom `onSubmitted` function while still maintaining the formatting features provided by this package.

Fixes #42 (they should use the new `onSubmitted` rather than `onChanged`)
May help with #48

Hopefully I've understood your code correctly, but let me know if you have any suggestions or changes.