### PR TITLE
Fix onSubmitted

### DIFF
--- a/lib/src/base_spin_box.dart
+++ b/lib/src/base_spin_box.dart
@@ -38,7 +38,6 @@ abstract class BaseSpinBox extends StatefulWidget {
   int get decimals;
   int get digits;
   ValueChanged<double>? get onChanged;
-  void Function(double value)? get onSubmitted;
   bool Function(double value)? get canChange;
   VoidCallback? get beforeChange;
   VoidCallback? get afterChange;
@@ -147,7 +146,7 @@ mixin SpinBoxMixin<T extends BaseSpinBox> on State<T> {
   }
 
   @protected
-  void fixupValue(String value) {
+  double fixupValue(String value) {
     final v = _parseValue(value);
     if (value.isEmpty || (v < widget.min || v > widget.max)) {
       // will trigger notify to _updateValue()
@@ -155,7 +154,7 @@ mixin SpinBoxMixin<T extends BaseSpinBox> on State<T> {
     } else {
       _cachedValue = _value;
     }
-    widget.onSubmitted?.call(_cachedValue);
+    return _cachedValue;
   }
 
   void _handleFocusChanged() {

--- a/lib/src/cupertino/spin_box.dart
+++ b/lib/src/cupertino/spin_box.dart
@@ -257,7 +257,6 @@ class CupertinoSpinBox extends BaseSpinBox {
   final ToolbarOptions? toolbarOptions;
 
   /// See [CupertinoTextField.onSubmitted]. Is called with a formatted value.
-  @override
   final void Function(double)? onSubmitted;
 
   @override
@@ -311,7 +310,10 @@ class _CupertinoSpinBoxState extends State<CupertinoSpinBox> with SpinBoxMixin {
         enabled: widget.enabled,
         readOnly: widget.readOnly,
         focusNode: focusNode,
-        onSubmitted: fixupValue,
+        onSubmitted: (v) {
+          final value = fixupValue(v);
+          widget.onSubmitted?.call(value);
+        },
       ),
     );
 

--- a/lib/src/material/spin_box.dart
+++ b/lib/src/material/spin_box.dart
@@ -265,7 +265,6 @@ class SpinBox extends BaseSpinBox {
   final ToolbarOptions? toolbarOptions;
 
   /// See [TextField.onSubmitted]. Is called with a formatted value.
-  @override
   final void Function(double)? onSubmitted;
 
   @override
@@ -416,7 +415,10 @@ class _SpinBoxState extends State<SpinBox> with SpinBoxMixin {
         enabled: widget.enabled,
         readOnly: widget.readOnly,
         focusNode: focusNode,
-        onSubmitted: fixupValue,
+        onSubmitted: (v) {
+          final value = fixupValue(v);
+          widget.onSubmitted?.call(value);
+        },
       ),
     );
 


### PR DESCRIPTION
Call it when TextField.onSubmitted() is called, not whenever the spinbox value is fixed up.

Fixes: #77