### PR TITLE
Fix deprecated_member_use

### DIFF
--- a/lib/src/cupertino/spin_box.dart
+++ b/lib/src/cupertino/spin_box.dart
@@ -74,7 +74,7 @@ class CupertinoSpinBox extends BaseSpinBox {
     this.direction = Axis.horizontal,
     this.textAlign = TextAlign.center,
     this.textStyle,
-    this.toolbarOptions,
+    this.contextMenuBuilder,
     this.showCursor,
     this.cursorColor,
     this.enableInteractiveSelection = true,
@@ -253,8 +253,8 @@ class CupertinoSpinBox extends BaseSpinBox {
   /// See [CupertinoTextField.style].
   final TextStyle? textStyle;
 
-  /// See [CupertinoTextField.toolbarOptions].
-  final ToolbarOptions? toolbarOptions;
+  /// See [CupertinoTextField.contextMenuBuilder].
+  final EditableTextContextMenuBuilder? contextMenuBuilder;
 
   /// See [TextField.onSubmitted].
   ///
@@ -281,7 +281,7 @@ class _CupertinoSpinBoxState extends State<CupertinoSpinBox> with SpinBoxMixin {
         textAlign: widget.textAlign,
         keyboardType: widget.keyboardType,
         textInputAction: widget.textInputAction,
-        toolbarOptions: widget.toolbarOptions,
+        contextMenuBuilder: widget.contextMenuBuilder,
         keyboardAppearance: widget.keyboardAppearance,
         inputFormatters: [formatter],
         prefix: Row(

--- a/lib/src/material/spin_box.dart
+++ b/lib/src/material/spin_box.dart
@@ -76,7 +76,7 @@ class SpinBox extends BaseSpinBox {
     this.textAlign = TextAlign.center,
     this.textDirection = TextDirection.ltr,
     this.textStyle,
-    this.toolbarOptions,
+    this.contextMenuBuilder,
     this.showCursor,
     this.cursorColor,
     this.enableInteractiveSelection = true,
@@ -261,8 +261,8 @@ class SpinBox extends BaseSpinBox {
   /// See [TextField.style].
   final TextStyle? textStyle;
 
-  /// See [TextField.toolbarOptions].
-  final ToolbarOptions? toolbarOptions;
+  /// See [TextField.contextMenuBuilder].
+  final EditableTextContextMenuBuilder? contextMenuBuilder;
 
   /// See [TextField.onSubmitted].
   ///
@@ -348,7 +348,7 @@ class _SpinBoxState extends State<SpinBox> with SpinBoxMixin {
     final isHorizontal = widget.direction == Axis.horizontal;
 
     if (isHorizontal) {
-      final caption = theme.textTheme.caption;
+      final caption = theme.textTheme.bodySmall;
       if (errorText != null) {
         bottom = _textHeight(errorText, caption!.merge(decoration.errorStyle));
       }
@@ -409,7 +409,7 @@ class _SpinBoxState extends State<SpinBox> with SpinBoxMixin {
         textDirection: widget.textDirection,
         keyboardType: widget.keyboardType,
         textInputAction: widget.textInputAction,
-        toolbarOptions: widget.toolbarOptions,
+        contextMenuBuilder: widget.contextMenuBuilder,
         keyboardAppearance: widget.keyboardAppearance,
         inputFormatters: [formatter],
         decoration: inputDecoration,


### PR DESCRIPTION
```
   info • 'toolbarOptions' is deprecated and shouldn't be used. Use `contextMenuBuilder` instead. This feature was deprecated after v3.3.0-0.5.pre • lib/src/cupertino/spin_box.dart:256:31 • deprecated_member_use
   info • 'ToolbarOptions' is deprecated and shouldn't be used. Use `contextMenuBuilder` instead. This feature was deprecated after v3.3.0-0.5.pre • lib/src/cupertino/spin_box.dart:257:9 • deprecated_member_use
   info • 'toolbarOptions' is deprecated and shouldn't be used. Use `contextMenuBuilder` instead. This feature was deprecated after v3.3.0-0.5.pre • lib/src/cupertino/spin_box.dart:284:9 • deprecated_member_use
   info • 'toolbarOptions' is deprecated and shouldn't be used. Use `contextMenuBuilder` instead. This feature was deprecated after v3.3.0-0.5.pre • lib/src/material/spin_box.dart:264:22 • deprecated_member_use
   info • 'ToolbarOptions' is deprecated and shouldn't be used. Use `contextMenuBuilder` instead. This feature was deprecated after v3.3.0-0.5.pre • lib/src/material/spin_box.dart:265:9 • deprecated_member_use
   info • 'caption' is deprecated and shouldn't be used. Use bodySmall instead. This feature was deprecated after v3.1.0-0.0.pre • lib/src/material/spin_box.dart:351:39 • deprecated_member_use
   info • 'toolbarOptions' is deprecated and shouldn't be used. Use `contextMenuBuilder` instead. This feature was deprecated after v3.3.0-0.5.pre • lib/src/material/spin_box.dart:412:9 • deprecated_member_use
```