### PR TITLE
fixed onSubmitted behavior and public State classes

### DIFF
--- a/lib/src/base_spin_box.dart
+++ b/lib/src/base_spin_box.dart
@@ -164,7 +164,7 @@ mixin SpinBoxMixin<T extends BaseSpinBox> on State<T> {
       if (hasFocus) {
         _selectAll();
       } else {
-        fixupValue(_controller.text);
+        widget.onSubmitted?.call(fixupValue(_controller.text));
       }
     });
   }

--- a/lib/src/base_spin_box.dart
+++ b/lib/src/base_spin_box.dart
@@ -164,7 +164,8 @@ mixin SpinBoxMixin<T extends BaseSpinBox> on State<T> {
       if (hasFocus) {
         _selectAll();
       } else {
-        widget.onSubmitted?.call(fixupValue(_controller.text));
+        final value = fixupValue(_controller.text);
+        widget.onSubmitted?.call(value);
       }
     });
   }

--- a/lib/src/cupertino/spin_box.dart
+++ b/lib/src/cupertino/spin_box.dart
@@ -265,10 +265,10 @@ class CupertinoSpinBox extends BaseSpinBox {
   final void Function(double)? onSubmitted;
 
   @override
-  State<CupertinoSpinBox> createState() => _CupertinoSpinBoxState();
+  State<CupertinoSpinBox> createState() => CupertinoSpinBoxState();
 }
 
-class _CupertinoSpinBoxState extends State<CupertinoSpinBox> with SpinBoxMixin {
+class CupertinoSpinBoxState extends State<CupertinoSpinBox> with SpinBoxMixin {
   @override
   Widget build(BuildContext context) {
     final isHorizontal = widget.direction == Axis.horizontal;

--- a/lib/src/material/spin_box.dart
+++ b/lib/src/material/spin_box.dart
@@ -273,10 +273,10 @@ class SpinBox extends BaseSpinBox {
   final void Function(double)? onSubmitted;
 
   @override
-  State<SpinBox> createState() => _SpinBoxState();
+  State<SpinBox> createState() => SpinBoxState();
 }
 
-class _SpinBoxState extends State<SpinBox> with SpinBoxMixin {
+class SpinBoxState extends State<SpinBox> with SpinBoxMixin {
   Color? _iconColor(ThemeData theme, String? errorText) {
     if (!widget.enabled) return theme.disabledColor;
     if (hasFocus && errorText == null) return theme.colorScheme.primary;


### PR DESCRIPTION
1. Calls onSubmitted with fixed up value in _handleFocusChanged. Otherwise there's no way to know the spinner value when the user switched to another form field after manually editing the value with keyboard.
2. Removed underscores from State classes names to make them public. This way we can use GlobalKey<SpinBoxState> with SpinBox'es and access their state.
