### PR TITLE
Check whether a focus state transition occurs

### DIFF
--- a/lib/src/base_spin_box.dart
+++ b/lib/src/base_spin_box.dart
@@ -52,6 +52,9 @@ mixin SpinBoxMixin<T extends BaseSpinBox> on State<T> {
   late final FocusNode _focusNode;
   late final TextEditingController _controller;
 
+  // record previous focus state
+  bool _hasFocusPrev = false;
+
   double get value => _value;
   bool get hasFocus => _focusNode.hasFocus;
   FocusNode get focusNode => _focusNode;
@@ -165,8 +168,13 @@ mixin SpinBoxMixin<T extends BaseSpinBox> on State<T> {
         _selectAll();
       } else {
         final value = fixupValue(_controller.text);
-        widget.onSubmitted?.call(value);
+        // Checking for valid state transitions is necessary
+        // because `_handleFocusChanged` is called when Spinbox are enabled
+        // or disabled.
+        if (_hasFocusPrev) widget.onSubmitted?.call(value);
       }
+
+      _hasFocusPrev = hasFocus;
     });
   }
 


### PR DESCRIPTION
Checking for valid state transitions is necessary because `_handleFocusChanged` is called when `Spinbox` are enabled or disabled.